### PR TITLE
Move `quickcheck-laws` out of dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,13 +20,13 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-maybe": "^3.0.0",
-    "purescript-quickcheck-laws": "^3.0.0"
+    "purescript-maybe": "^3.0.0"
   },
   "devDependencies": {
     "purescript-integers": "^3.0.0",
     "purescript-console": "^3.0.0",
     "purescript-assert": "^3.0.0",
-    "purescript-quickcheck": "^4.0.0"
+    "purescript-quickcheck": "^4.0.0",
+    "purescript-quickcheck-laws": "^3.0.0"
   }
 }


### PR DESCRIPTION
I presume `quickcheck-laws` is just a devDependency. This PR is to move it to that section of the `bower.json` file.

Mostly this is for correctness, but it's also because I'm being hit by a bug where documentation doesn't generate due to something around the Quickcheck library, and BigInt is one of the libs I have installed. While diagnosing I noticed that the laws package was incorrectly categorized.