### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/Data/BigInt.js
+++ b/src/Data/BigInt.js
@@ -2,7 +2,7 @@
 
 var bigInt = require("big-integer");
 
-exports["fromBase'"] = function(just) {
+exports.fromBaseImpl = function(just) {
   return function(nothing) {
     return function(b) {
       return function(s) {
@@ -22,7 +22,7 @@ function truncate(n) {
   return Math.ceil(n);
 }
 
-exports["fromNumber'"] = function(just) {
+exports.fromNumberImpl = function(just) {
   return function(nothing) {
       return function(n) {
         try {

--- a/src/Data/BigInt.purs
+++ b/src/Data/BigInt.purs
@@ -45,7 +45,7 @@ type BaseDigits =
   }
 
 -- | FFI wrapper to parse a String in a given base representation into a BigInt.
-foreign import fromBase'
+foreign import fromBaseImpl
   :: forall a
    . (a -> Maybe a)
   -> Maybe a
@@ -57,7 +57,7 @@ foreign import fromBase'
 foreign import fromInt :: Int -> BigInt
 
 -- | FFI wrapper to parse a Number into a BigInt.
-foreign import fromNumber'
+foreign import fromNumberImpl
   :: forall a
    . (a -> Maybe a)
   -> Maybe a
@@ -66,7 +66,7 @@ foreign import fromNumber'
 
 -- | Convert a Number to a BigInt. The fractional part is truncated.
 fromNumber :: Number -> Maybe BigInt
-fromNumber = fromNumber' Just Nothing
+fromNumber = fromNumberImpl Just Nothing
 
 -- | Converts a BigInt to a Number. Loses precision for numbers which are too
 -- | large.
@@ -127,7 +127,7 @@ fromString = fromBase 10
 -- | fromBase 16 "ff" == fromString "255"
 -- | ```
 fromBase :: Int -> String -> Maybe BigInt
-fromBase = fromBase' Just Nothing
+fromBase = fromBaseImpl Just Nothing
 
 foreign import biEquals :: BigInt -> BigInt -> Boolean
 


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.