### PR TITLE
Update for PureScript 0.14

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,17 +20,17 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-maybe": "^4.0.0",
-    "purescript-integers": "^4.0.0",
-    "purescript-strings": "^4.0.0"
+    "purescript-maybe": "^5.0.0",
+    "purescript-integers": "^5.0.0",
+    "purescript-strings": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-integers": "^4.0.0",
-    "purescript-console": "^4.1.0",
-    "purescript-assert": "^4.0.0",
-    "purescript-quickcheck": "^6.0.0",
-    "purescript-quickcheck-laws": "^5.0.0",
-    "purescript-psci-support": "^4.0.0",
-    "purescript-effect": "^2.0.0"
+    "purescript-integers": "^5.0.0",
+    "purescript-console": "^5.0.0",
+    "purescript-assert": "^5.0.0",
+    "purescript-quickcheck": "^7.0.0",
+    "purescript-quickcheck-laws": "^6.0.0",
+    "purescript-psci-support": "^5.0.0",
+    "purescript-effect": "^3.0.0"
   }
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,17 +3,17 @@ module Test.Main where
 import Prelude hiding (not)
 
 import Data.Array (filter, range)
+import Data.Array.NonEmpty (cons')
 import Data.Array.NonEmpty as NEA
 import Data.BigInt (BigInt, abs, and, digitsInBase, even, fromBase, fromInt, fromNumber, fromString, not, odd, or, pow, prime, shl, shr, toBase, toBase', toNonEmptyString, toNumber, toString, xor, quot, rem, toInt)
 import Data.Foldable (fold)
 import Data.Int as Int
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.NonEmpty ((:|))
+import Data.Number (infinity, nan)
 import Data.String.NonEmpty (unsafeFromString)
 import Data.String.NonEmpty as NES
 import Effect (Effect)
 import Effect.Console (log)
-import Global (infinity, nan)
 import Partial.Unsafe (unsafePartial)
 import Test.Assert (assert)
 import Test.QuickCheck (quickCheck)
@@ -43,7 +43,7 @@ derive newtype instance euclideanRingTestBigInt :: EuclideanRing TestBigInt
 instance arbitraryBigInt :: Arbitrary TestBigInt where
   arbitrary = do
     n <- (fromMaybe zero <<< fromString) <$> digitString
-    op <- elements (identity :| [negate])
+    op <- elements (cons' identity [negate])
     pure (TestBigInt (op n))
     where digits :: Gen Int
           digits = chooseInt 0 9


### PR DESCRIPTION
This PR updates the library dependencies and tests for PureScript 0.14.

- Each version received a major version bump for PureScript 0.14 compatibility
- The `globals` package has been deprecated, and `nan` and `infinity` moved into `numbers` (thanks for adding that to core, by the way!)
- The `elements` function in QuickCheck now uses `NonEmptyArray` instead of `NonEmpty Array`

If everything looks good, we'll want to make a major version release of this library and I can then take care of updating this in the package sets for you.